### PR TITLE
Update eu_docs.lua

### DIFF
--- a/conf/conf.d/eu_docs.lua
+++ b/conf/conf.d/eu_docs.lua
@@ -128,7 +128,7 @@ if (not eu_core.file_exists(user_file)) then
     "      {\n",
     "          e.DOCTYPE_CS,\n",
     "          \"cshape\",\n",
-    "          \";*.cs;*.ci;*.csx;*.vala;*.vapi;\",\n",
+    "          \";*.cs;*.ci;*.csx;*.fu;*.vala;*.vapi;\",\n",
     "          \"C#\",\n",
     "          \"cshape.snippets\",\n",
     "          0,\n",


### PR DESCRIPTION
Cito programming language changed it name to Fusion and the source extension to .fu